### PR TITLE
plotly 5.6.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "5.1.0" %}
+{% set version = "5.6.0" %}
 
 package:
   name: plotly
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/p/plotly/plotly-{{ version }}.tar.gz
-  sha256: 71f6744acdc524c22236c226d7cf1072d1a58ebacaf749c640998298472c8c44
+  sha256: d86e44ebde38f4753dff982ab9b5e03cf872aab8fdf53a403e999ed378154331
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,11 +1,12 @@
+{% set name = "plotly" %}
 {% set version = "5.6.0" %}
 
 package:
-  name: plotly
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/p/plotly/plotly-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/plotly-{{ version }}.tar.gz
   sha256: d86e44ebde38f4753dff982ab9b5e03cf872aab8fdf53a403e999ed378154331
 
 build:
@@ -15,7 +16,7 @@ build:
 
 requirements:
   host:
-    - python >=3.6
+    - python
     - pip
     - setuptools >=40.8.0
     - wheel
@@ -26,13 +27,13 @@ requirements:
     # retrying requests
     - tenacity >=6.2.0
     # python 2 to 3 compatibility
-    - six ==1.15.0
+    - six >=1.15.0
 
 test:
   requires:
     - pip
     - {{ pin_compatible('numpy') }}
-    - matplotlib
+    - matplotlib-base
     - pandas
   commands:
     - pip check
@@ -51,9 +52,6 @@ test:
     - plotly.express.data
     - plotly.express.colors
     - plotly.graph_objects
-    - _plotly_utils
-    - _plotly_utils.colors
-    - _plotly_future_
 
 about:
   home: https://plot.ly/python/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,6 @@ requirements:
     - pip
     - setuptools >=40.8.0
     - wheel
-    - jupyterlab >=3.0
   run:
     - python >=3.6
     # Dependencies for Core Plotly Functionality:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/plotly-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: d86e44ebde38f4753dff982ab9b5e03cf872aab8fdf53a403e999ed378154331
 
 build:


### PR DESCRIPTION
Update plotly to 5.6.0

Bug Tracker: new open issues https://github.com/plotly/plotly.py/issues
Upstream license: https://github.com/plotly/plotly.py/blob/master/packages/python/plotly/LICENSE.txt
Upstream Changelog: https://github.com/plotly/plotly.py/blob/master/CHANGELOG.md
Upstream setup.py:  
- https://github.com/plotly/plotly.py/blob/v5.6.0/packages/python/plotly/setup.py
- https://github.com/plotly/plotly.py/blame/v5.6.0/packages/python/plotly/requirements.txt
- https://github.com/plotly/plotly.py/blob/v5.6.0/packages/python/plotly/recipe/meta.yaml

Upstream pyproject.toml:  https://github.com/plotly/plotly.py/blob/v5.6.0/packages/python/plotly/pyproject.toml

The package plotly is mentioned inside the packages:
autovizwidget | dash | dash-bio | dash-core-components | dash-html-components | dash-renderer | dash-table | glue-core | 

Actions:
1. Fix pinning for `six`
2. Update `test/requires`: remove private packages
3. Update `source/url` with jinja2 templates
4. Use `matplotlib-base` in test/requires
5. Fix `python` in host for noarch package

Result:
- all-succeeded