### PR TITLE
plotly 5.24.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "plotly" %}
-{% set version = "5.24.0" %}
+{% set version = "5.24.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: eae9f4f54448682442c92c1e97148e3ad0c52f0cf86306e1b76daba24add554a
+  sha256: dbc8ac8339d248a4bcc36e08a5659bacfe1b079390b8953533f4eb22169b4bae
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "plotly" %}
-{% set version = "5.22.0" %}
+{% set version = "5.24.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 859fdadbd86b5770ae2466e542b761b247d1c6b49daed765b95bb8c7063e7469
+  sha256: eae9f4f54448682442c92c1e97148e3ad0c52f0cf86306e1b76daba24add554a
 
 build:
   number: 0


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-5591](https://anaconda.atlassian.net/browse/PKG-5591)
- [Upstream repository](https://github.com/plotly/plotly.py/tree/v5.24.0)
- [Upstream changelog/diff](https://github.com/plotly/plotly.py/blob/v5.24.0/CHANGELOG.md)

### Explanation of changes:

- Update version and sha256


[PKG-5591]: https://anaconda.atlassian.net/browse/PKG-5591?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ