### PR TITLE
plotly 5.24.1 (py313 rebuild)

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 1
-  skip: true  # [py<38]
+  skip: true  # [py<38] 
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: dbc8ac8339d248a4bcc36e08a5659bacfe1b079390b8953533f4eb22169b4bae
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<38]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 


### PR DESCRIPTION
plotly 5.24.1 

**Destination channel:** Defaults

### Links

- [PKG-7178]
- dev_url:        https://github.com/plotly/plotly.py/tree/v5.24.1
- conda_forge:    None
- pypi:           n/a
- pypi inspector: n/a

### Explanation of changes:

- new version number


[PKG-7178]: https://anaconda.atlassian.net/browse/PKG-7178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ