### PR TITLE
plotly 6.0.1

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY313 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "plotly" %}
-{% set version = "5.24.1" %}
+{% set version = "6.0.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,30 +7,30 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: dbc8ac8339d248a4bcc36e08a5659bacfe1b079390b8953533f4eb22169b4bae
+  sha256: dd8400229872b6e3c964b099be699f8d00c489a974f2cfccfad5e8240873366b
 
 build:
-  number: 1
-  skip: true  # [py<38] 
+  number: 0
+  skip: true  # [py<38]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
     - python
     - pip
-    - setuptools >=40.8.0
+    - setuptools
     - wheel
   run:
     - python
     - packaging
     - tenacity >=6.2.0
+    - narwhals >=1.15.1
   run_constrained:
     - jupyterlab >=3
     - ipywidgets >=7.6
 
 test:
   imports:
-    - jupyterlab_plotly
     - plotly
     - plotly.offline
     - plotly.io
@@ -45,9 +45,6 @@ test:
     - plotly.express.colors
     - plotly.express.trendline_functions
     - plotly.graph_objects
-    - _plotly_utils
-    - _plotly_utils.colors
-    - _plotly_future_
     - plotly.graph_objs
     - plotly.graph_objs.bar
     - plotly.graph_objs.barpolar
@@ -63,7 +60,6 @@ test:
     - plotly.graph_objs.funnel
     - plotly.graph_objs.funnelarea
     - plotly.graph_objs.heatmap
-    - plotly.graph_objs.heatmapgl
     - plotly.graph_objs.histogram
     - plotly.graph_objs.histogram2d
     - plotly.graph_objs.histogram2dcontour
@@ -77,7 +73,6 @@ test:
     - plotly.graph_objs.parcats
     - plotly.graph_objs.parcoords
     - plotly.graph_objs.pie
-    - plotly.graph_objs.pointcloud
     - plotly.graph_objs.sankey
     - plotly.graph_objs.scatter
     - plotly.graph_objs.scatter3d
@@ -114,7 +109,6 @@ test:
     - plotly.validators.funnel
     - plotly.validators.funnelarea
     - plotly.validators.heatmap
-    - plotly.validators.heatmapgl
     - plotly.validators.histogram
     - plotly.validators.histogram2d
     - plotly.validators.histogram2dcontour
@@ -128,7 +122,6 @@ test:
     - plotly.validators.parcats
     - plotly.validators.parcoords
     - plotly.validators.pie
-    - plotly.validators.pointcloud
     - plotly.validators.sankey
     - plotly.validators.scatter
     - plotly.validators.scatter3d

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -51,10 +51,12 @@ test:
     - plotly.graph_objs.candlestick
     - plotly.graph_objs.carpet
     - plotly.graph_objs.choropleth
+    - plotly.graph_objs.choroplethmap
     - plotly.graph_objs.choroplethmapbox
     - plotly.graph_objs.cone
     - plotly.graph_objs.contour
     - plotly.graph_objs.contourcarpet
+    - plotly.graph_objs.densitymap
     - plotly.graph_objs.densitymapbox
     - plotly.graph_objs.funnel
     - plotly.graph_objs.funnelarea
@@ -78,6 +80,7 @@ test:
     - plotly.graph_objs.scattercarpet
     - plotly.graph_objs.scattergeo
     - plotly.graph_objs.scattergl
+    - plotly.graph_objs.scattermap
     - plotly.graph_objs.scattermapbox
     - plotly.graph_objs.scatterpolar
     - plotly.graph_objs.scatterpolargl
@@ -92,6 +95,9 @@ test:
     - plotly.graph_objs.violin
     - plotly.graph_objs.volume
     - plotly.graph_objs.waterfall
+    - plotly.package_data
+    - plotly.package_data.datasets
+    - plotly.package_data.templates
     - plotly.validators
     - plotly.validators.bar
     - plotly.validators.barpolar
@@ -99,10 +105,12 @@ test:
     - plotly.validators.candlestick
     - plotly.validators.carpet
     - plotly.validators.choropleth
+    - plotly.validators.choroplethmap
     - plotly.validators.choroplethmapbox
     - plotly.validators.cone
     - plotly.validators.contour
     - plotly.validators.contourcarpet
+    - plotly.validators.densitymap
     - plotly.validators.densitymapbox
     - plotly.validators.frame
     - plotly.validators.funnel
@@ -127,6 +135,7 @@ test:
     - plotly.validators.scattercarpet
     - plotly.validators.scattergeo
     - plotly.validators.scattergl
+    - plotly.validators.scattermap
     - plotly.validators.scattermapbox
     - plotly.validators.scatterpolar
     - plotly.validators.scatterpolargl

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,6 @@ requirements:
   run:
     - python
     - packaging
-    - tenacity >=6.2.0
     - narwhals >=1.15.1
   run_constrained:
     - jupyterlab >=3


### PR DESCRIPTION
**Destination channel:** main

### Links

- [Jira](https://anaconda.atlassian.net/browse/PKG-6939) 
- [Upstream repo](https://github.com/plotly/plotly.py/tree/v6.0.1)
- release-diff: https://github.com/plotly/plotly.py/compare/v5.24.1...v6.0.1
- changelog: https://github.com/plotly/plotly.py/blob/main/CHANGELOG.md
- requirements-tagged:
  - https://github.com/plotly/plotly.py/blob/v6.0.1/pyproject.toml


### Explanation of changes:

- Reset build number from 1 to 0
- Remove `tenacity` from `run`
- Remove several import tests for modules that have been deprecated or removed:
```
_plotly_utils
_plotly_utils.colors
_plotly_future_
plotly.graph_objs.heatmapgl
plotly.graph_objs.pointcloud
plotly.validators.heatmapgl
plotly.validators.pointcloud
```
- Completely remove abs.yaml file

### Notes:

- I've tested the package with donwstreams:
```
Downstream build order (groups:() feedstocks:('plotly-feedstock',) packages:() allow_list:() block_list:() drop_noarch:False sections:('build', 'host', 'run')):

000 dash-feedstock                 ['dash']
001 anaconda-feedstock             ['_anaconda_depends', '_anaconda_core', '__anaconda_core_depends']
001 chart-studio-feedstock         ['chart-studio']
001 plotly-resampler-feedstock     ['plotly-resampler']
002 anaconda_custom-feedstock      ['anaconda']
002 autovizwidget-feedstock        ['autovizwidget']
002 bertopic-feedstock             ['bertopic']
002 catboost-feedstock             ['catboost']
002 dash-bio-feedstock             ['dash-bio']
002 glue-core-feedstock            ['glue-core']
002 interpret-feedstock            ['interpret']
002 python-cufflinks-feedstock     ['python-cufflinks']
002 sdmetrics-feedstock            ['sdmetrics']
002 statsforecast-feedstock        ['statsforecast']
002 streamlit-plotly-events-feedstock ['streamlit-plotly-events']
```

No issues found.