### PR TITLE
plotly 6.7.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,11 +26,11 @@ requirements:
     - packaging
     - narwhals >=1.15.1
   run_constrained:
-    # Upstream's `kaleido` extra pins kaleido>=1.1.0, but pkgs/main currently
-    # only ships python-kaleido 0.2.1. Constrain to the available floor so the
-    # `conda install plotly python-kaleido` path is satisfiable. Bump to
-    # >=1.1.0 once python-kaleido 1.1+ lands on pkgs/main.
-    - python-kaleido >=0.2.1
+    # Upstream's `kaleido` extra (plotly 6.7.0 pyproject.toml) pins
+    # `kaleido>=1.1.0`. python-kaleido 1.3.0 now ships on pkgs/main, so match
+    # upstream's semantic — plotly's chrome-based image-export path requires
+    # the kaleido-1.x API (`plotly_get_chrome`, `kaleido.Kaleido`).
+    - python-kaleido >=1.1.0
 
 # E   ModuleNotFoundError: No module named 'pdfrw'
 {% set ignore_tests = " --ignore=tests/test_optional/test_kaleido/test_kaleido.py" %}
@@ -159,13 +159,11 @@ test:
     - plotly.validators
   commands:
     - pip check
-    # TODO: re-enable once python-kaleido >=1.1.0 lands on pkgs/main and is
-    # added to test.requires below. plotly_get_chrome's body raises a
-    # ValueError before parsing --help if kaleido is missing or major < 1
-    # (plotly/io/_kaleido.py: kaleido_available() / kaleido_major() < 1),
-    # so the invocation cannot be exercised on the currently-available
-    # python-kaleido 0.2.1.
-    # - plotly_get_chrome --help
+    # plotly_get_chrome's body raises ValueError unless kaleido major >= 1
+    # (see plotly/io/_kaleido.py: kaleido_available() / kaleido_major() < 1).
+    # python-kaleido 1.3.0 now on pkgs/main → safe to re-enable; needs
+    # python-kaleido in test.requires below.
+    - plotly_get_chrome --help
     - pytest tests {{ ignore_tests }} {{ deselect_tests }}
   requires:
     - pip
@@ -184,6 +182,8 @@ test:
     - nbformat >=4.2.0
     - scikit-image
     - pytz
+    # Needed for plotly_get_chrome --help (kaleido_major() >= 1 check)
+    - python-kaleido >=1.1.0
 
 about:
   home: https://plotly.com/python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,11 @@ requirements:
     - packaging
     - narwhals >=1.15.1
   run_constrained:
-    - python-kaleido >=1.1.0
+    # Upstream's `kaleido` extra pins kaleido>=1.1.0, but pkgs/main currently
+    # only ships python-kaleido 0.2.1. Constrain to the available floor so the
+    # `conda install plotly python-kaleido` path is satisfiable. Bump to
+    # >=1.1.0 once python-kaleido 1.1+ lands on pkgs/main.
+    - python-kaleido >=0.2.1
 
 # E   ModuleNotFoundError: No module named 'pdfrw'
 {% set ignore_tests = " --ignore=tests/test_optional/test_kaleido/test_kaleido.py" %}
@@ -155,7 +159,12 @@ test:
     - plotly.validators
   commands:
     - pip check
-    # needs python-kaleido >=1.1.0
+    # TODO: re-enable once python-kaleido >=1.1.0 lands on pkgs/main and is
+    # added to test.requires below. plotly_get_chrome's body raises a
+    # ValueError before parsing --help if kaleido is missing or major < 1
+    # (plotly/io/_kaleido.py: kaleido_available() / kaleido_major() < 1),
+    # so the invocation cannot be exercised on the currently-available
+    # python-kaleido 0.2.1.
     # - plotly_get_chrome --help
     - pytest tests {{ ignore_tests }} {{ deselect_tests }}
   requires:
@@ -181,11 +190,11 @@ about:
   license: MIT
   license_family: MIT
   license_file: LICENSE.txt
-  summary: An interactive JavaScript-based visualization library for Python
+  summary: An open-source interactive data visualization library for Python
   description: |
-    plotly.py is an interactive, open-source, and JavaScript-based graphing
+    plotly.py is an interactive, open-source, and browser-based graphing
     library for Python. Built on top of plotly.js, plotly.py is a high-level,
-    declarative charting library that includes over 30 chart types,
+    declarative charting library. plotly.js ships with over 30 chart types,
     including scientific charts, 3D graphs, statistical charts, SVG maps,
     financial charts, and more.
   doc_url: https://plotly.com/python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "plotly" %}
-{% set version = "6.6.0" %}
+{% set version = "6.7.0" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/{{ name }}/{{ name }}.py/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 785ad8f0bebe1f4d53dcda37fd2cd0f7cf8b1e1a528c663c08df74d20a57ad4e
+  sha256: 3cca70b7cd1ad19d0e1355886f85d4f6f8e0068133013e17c9e035287b74a1d3
 
 build:
   number: 0
@@ -20,9 +20,7 @@ requirements:
   host:
     - pip
     - python
-    - wheel
-    - setuptools >=61
-    - jupyter-packaging >=0.10.0,<0.11
+    - hatchling >=1.26
   run:
     - python
     - packaging

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -159,11 +159,12 @@ test:
     - plotly.validators
   commands:
     - pip check
-    # plotly_get_chrome's body raises ValueError unless kaleido major >= 1
-    # (see plotly/io/_kaleido.py: kaleido_available() / kaleido_major() < 1).
-    # python-kaleido 1.3.0 now on pkgs/main → safe to re-enable; needs
-    # python-kaleido in test.requires below.
-    - plotly_get_chrome --help
+    # plotly_get_chrome is unusable with `--help` because upstream's CLI does
+    # manual sys.argv parsing (plotly/io/_kaleido.py L795-847) and treats
+    # `--help` as an unrecognized argument — prints usage then `sys.exit(1)`.
+    # The `--help` line in its own usage text is documentation, not a real
+    # handler. Verify the entry point is reachable via Python instead.
+    - python -c "from plotly.io._kaleido import plotly_get_chrome; assert callable(plotly_get_chrome)"
     - pytest tests {{ ignore_tests }} {{ deselect_tests }}
   requires:
     - pip


### PR DESCRIPTION
## plotly 6.7.0

**Destination channel:** defaults

### Links
- [PKG-13847](https://anaconda.atlassian.net/browse/PKG-13847)
- [PyPI](https://pypi.org/project/plotly/6.7.0/)
- [GitHub release](https://github.com/plotly/plotly.py/releases/tag/v6.7.0)
- [CHANGELOG](https://github.com/plotly/plotly.py/blob/v6.7.0/CHANGELOG.md)

### Explanation of changes
- Bumped plotly from 6.6.0 to 6.7.0 (version + sha256).
- **Build backend change**: upstream replaced `setuptools + jupyter_packaging` with `hatchling >= 1.26` in `pyproject.toml`. Updated host accordingly:
  - dropped `setuptools >=61`, `wheel`, `jupyter-packaging >=0.10.0,<0.11`
  - added `hatchling >=1.26`
- Runtime deps unchanged (`narwhals >=1.15.1`, `packaging`).
- Optional `kaleido>=1.1.0` extra remains mapped to `python-kaleido >=1.1.0` in `run_constrained`.
- Entry point `plotly_get_chrome` still present upstream and preserved in build.

[PKG-13847]: https://anaconda.atlassian.net/browse/PKG-13847?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ